### PR TITLE
Remove cheaty .length() with PaleolithicNatural

### DIFF
--- a/math.cpp
+++ b/math.cpp
@@ -385,7 +385,7 @@ struct PaleolithicNatural
 template<bool dotCompareValue>
 auto const
 dotCompare =
-    [](char leftDot, char rightDot)
+    [](char leftDot, char rightDot) -> bool
     {
         // Both dots look the same to me
         return dotCompareValue;
@@ -394,7 +394,7 @@ dotCompare =
 // Helper function for splitting a string of dots into two piles, with support for rest elements
 template<typename PairHandler, typename LastElementHandler>
 auto
-splitDots(PaleolithicNatural const & x, PairHandler &&pairHandler, LastElementHandler &&lastHandler) -> void
+splitDots(PaleolithicNatural const& x, PairHandler&& pairHandler, LastElementHandler&& lastHandler) -> void
 {
     // Let's go through each pair of dots in this number
     for(auto it = x.n.begin(); it != x.n.end(); ++ it)
@@ -459,7 +459,7 @@ operator+(PaleolithicNatural const& x0, PaleolithicNatural const& x1) -> Paleoli
 // Natural number half and is_odd
 
 auto
-half(PaleolithicNatural const & x) -> PaleolithicNatural
+half(PaleolithicNatural const& x) -> PaleolithicNatural
 {
     PaleolithicNatural halfBuilder;
     splitDots(

--- a/math.cpp
+++ b/math.cpp
@@ -465,7 +465,7 @@ half(PaleolithicNatural const& x) -> PaleolithicNatural
     splitDots(
         x,
         // Split the dots into two piles, for each pair, add one to our return value
-        [&halfBuilder](char firstDot, char seconDot)
+        [&halfBuilder](char firstDot, char secondDot)
         {
             halfBuilder.n += firstDot;
         },
@@ -488,7 +488,7 @@ is_odd(PaleolithicNatural const& x) -> bool
     splitDots(
         x,
         // Split the dots into two piles, we don't care about complete pairs
-        [](char firstDot, char seconDot)
+        [](char firstDot, char secondDot)
         { },
         // If we end up with a rest dot, x is odd
         [&oddYet](char restDot)


### PR DESCRIPTION
As the declaration states, the constructor `PaleolithicNatural(unsigned)` is purposed to take an `unsigned` as an interface "for the Renissance person"

This PR removes all such horrible usages of the helper interface within the implementation by changing multiplication, comparison, `half()` and `is_odd()` of the aforementioned unsigned integral type. These functions now use concepts which do not involve length, as it is accomplishes nothing to speak about the length of a an equal count of what you're trying to count in the first place. We implement parity by dividing our dots into two piles etc.

You may not want to merge this into the main branch though, as people coming from your talk may want to see your original implementation, but this should be merged into any current production environment as soon as possible to avoid any terrifying mishappenings.